### PR TITLE
revamp .gittatributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,40 @@
 * text eol=lf
-* binary eol=auto
+
+*.py    text diff=python
+*.ini   text
+*.txt   text
+*.md    text
+*.ino   text
+*.h     text
+*.yml   text
+*.sh    text
+
+# These files are binary and should be left untouched
+# (binary is a macro for -text -diff)
+*.png binary
+*.jpg binary
+*.jpeg binary
+*.gif binary
+*.ico binary
+*.mov binary
+*.mp4 binary
+*.mp3 binary
+*.flv binary
+*.fla binary
+*.swf binary
+*.gz binary
+*.zip binary
+*.7z binary
+*.ttf binary
+
+# Documents
+*.doc  binary
+*.DOC  binary
+*.docx binary
+*.DOCX binary
+*.dot  binary
+*.DOT  binary
+*.pdf  binary
+*.PDF  binary
+*.rtf  binary
+*.RTF  binary


### PR DESCRIPTION
`git diff` recognized .py and .ini as binary files.
The reason for this was the `* binary eol=auto` rule,
which treated all files as binary, unless explicitly
listed otherwise.

Since we will mostly deal with text files, this change
makes text files the default.